### PR TITLE
Use Net::HTTP.new.start to use proxy settings

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -173,7 +173,7 @@ module Fastlane
       def self.upload(upload, path)
         url = URI.parse(upload.url)
         contents = File.open(path, 'rb').read
-        Net::HTTP.start(url.host) do |http|
+        Net::HTTP.new(url.host).start do |http|
           http.send_request("PUT", url.request_uri, contents, { 'content-type' => 'application/octet-stream' })
         end
       end


### PR DESCRIPTION
When using Net::HTTP.start, the http_proxy and https_proxy environment variables are not taken into account. With this change, the plugin can be used behind a proxy.