### PR TITLE
Added initialized status as condition to wait for upload

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -193,7 +193,7 @@ module Fastlane
 
       def self.wait_for_upload(upload)
         upload = fetch_upload_status upload
-        while upload.status == 'PROCESSING'
+        while upload.status == 'PROCESSING' || upload.status == 'INITIALIZED'
           sleep POLLING_INTERVAL
           upload = fetch_upload_status upload
         end


### PR DESCRIPTION
 Added INITIALIZED status to the wait_for_upload method as per valid statuses listed on: [Amazon's docs](http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Upload.html).
