### PR TITLE
Option to allow device booting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ lane :aws_device_run_ios do
   ENV['AWS_ACCESS_KEY_ID']     = 'xxxxx'
   ENV['AWS_SECRET_ACCESS_KEY'] = 'xxxxx'
   ENV['AWS_REGION']            = 'us-west-2'
-  
   #Build For Testing
   xcodebuild(
     scheme: 'UITests',
@@ -78,7 +77,7 @@ end
 ## Options
 
  * **aws_device_farm**
- 
+
 |  Option |  Default  |  Description |  Type |
 |---|---|---|---|
 |  name |  fastlane  |  AWS Device Farm Project Name |  String |
@@ -86,7 +85,7 @@ end
 |  test_binary_path |    |  Path to App Binary |  String |
 |  device_pool | IOS | AWS Device Farm Device Pool | String |
 |  wait_for_completion | true | Wait for Test-Run to be completed | Boolean |
-
+|  allow_device_errors | false | Do you want to allow device booting errors? | Boolean |
 
 
 * **aws_device_farm_package**
@@ -97,7 +96,6 @@ end
 |  derrived_data_path |  Development   |  Specify the Build-Configuration that was used e.g.: Development |  String |
 
 
-
 ## Credit
 it is based on a custom action by @icapps (https://github.com/icapps/fastlane-configuration)
 added the following:
@@ -105,7 +103,7 @@ added the following:
   * support current `fastlane` version
   * improve output
   * make it available as a `fastlane` plugin
-  
+
 
 ## Troubleshooting
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -59,8 +59,11 @@ module Fastlane
         if params[:wait_for_completion]
           UI.message 'Waiting for the run to complete. ☕️'
           run = wait_for_run run
-          raise "#{run.message} Failed 🙈" unless %w(PASSED WARNED).include? run.result
-
+          if params[:allow_device_errors] == true
+            raise "#{run.message} Failed 🙈" unless %w(PASSED WARNED ERRORED).include? run.result
+          else
+            raise "#{run.message} Failed 🙈" unless %w(PASSED WARNED).include? run.result
+          end
           UI.message 'Successfully tested the application on the AWS device farm. ✅'.green
         else
           UI.message 'Successfully scheduled the tests on the AWS device farm. ✅'.green
@@ -115,7 +118,6 @@ module Fastlane
             verify_block: proc do |value|
               raise "Test binary not found at path '#{value}'. 🙈".red unless File.exist?(File.expand_path(value))
             end
-
           ),
           FastlaneCore::ConfigItem.new(
             key:         :path,
@@ -142,6 +144,14 @@ module Fastlane
             is_string:     false,
             optional:      true,
             default_value: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key:           :allow_device_errors,
+            env_name:      'FL_AWS_DEVICE_FARM_ALLOW_ERROR',
+            description:   'Do you want to allow device booting errors?',
+            is_string:     false,
+            optional:      true,
+            default_value: false
           )
         ]
       end
@@ -249,9 +259,11 @@ module Fastlane
         rows = []
         job.jobs.each do |j|
           if j.result == "PASSED"
-            status = "💚"
+            status = "💚 (#{j.result})"
+          elsif j.result == "ERRORED"
+            status = "📵 (#{j.result})"
           else
-            status = "💥"
+            status = "💥 (#{j.result})"
           end
           rows << [status, j.name, j.device.form_factor, j.device.platform, j.device.os]
         end

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -60,9 +60,9 @@ module Fastlane
           UI.message 'Waiting for the run to complete. ☕️'
           run = wait_for_run run
           if params[:allow_device_errors] == true
-            raise "#{run.message} Failed 🙈" unless %w(PASSED WARNED ERRORED).include? run.result
+            raise "#{run.message} Failed 🙈" unless %w[PASSED WARNED ERRORED].include? run.result
           else
-            raise "#{run.message} Failed 🙈" unless %w(PASSED WARNED).include? run.result
+            raise "#{run.message} Failed 🙈" unless %w[PASSED WARNED].include? run.result
           end
           UI.message 'Successfully tested the application on the AWS device farm. ✅'.green
         else


### PR DESCRIPTION
Currently, we experience a lot of device booting issues on the AWS device farm. It would be nice to ignore this errors and purely focus on the tests which run on the device farm. I added a parameter which to allow this errors on your build. Also, I added the reason for failing to the output log.