### PR TITLE
Add test filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The plugin also exposes two ENV variables in case you want to make additional ca
 |  wait_for_completion | true | Wait for Test-Run to be completed | Boolean |
 |  allow_device_errors | false | Do you want to allow device booting errors? | Boolean |
 |  allow_failed_tests | false | Do you want to allow failing tests? | Boolean |
+|  filter |    | Define a filter for your test run and only run the tests in the filter | String |
 
 Possible types see: http://docs.aws.amazon.com/sdkforruby/api/Aws/DeviceFarm/Client.html#create_upload-instance_method
 

--- a/fastlane-plugin-aws_device_farm.gemspec
+++ b/fastlane-plugin-aws_device_farm.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk'
 
-  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'fastlane', '>= 1.105.0'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop'
 end

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -214,6 +214,14 @@ module Fastlane
             is_string:     false,
             optional:      true,
             default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key:           :filter,
+            env_name:      'FL_AWS_DEVICE_FARM_FILTER',
+            description:   'Define a filter for your test run and only run the tests in the filter',
+            is_string:     true,
+            optional:      true,
+            default_value: ''
           )
         ]
       end
@@ -294,6 +302,7 @@ module Fastlane
           end
 
           test_hash[:test_package_arn] = test_upload.arn
+          test_hash[:filter] = params[:filter]
         end
 
         @client.schedule_run({


### PR DESCRIPTION
As suggested in issue #13. 

Added the filter feature available in the aws device-farm api.

I already extended this plugin for a project of my own, so why not share the changes. 