### PR TITLE
Add ability to pass locale

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -230,7 +230,14 @@ module Fastlane
             is_string:     true,
             optional:      true,
             default_value: 'METERED' # accepts METERED, UNMETERED
-          )
+          ),
+          FastlaneCore::ConfigItem.new(
+            key:           :locale,
+            env_name:      'FL_AWS_DEVICE_FARM_LOCALE',
+            description:   'Specify the locale for the run',
+            is_string:     true,
+            optional:      true,
+            default_value: 'en_US')
         ]
       end
 
@@ -314,8 +321,9 @@ module Fastlane
         end
 
         configuration_hash = {
+          billing_method: params[:billing_method],
+          locale: params[:locale]
         }
-        configuration_hash[:billing_method] = params[:billing_method]
 
         @client.schedule_run({
           name:            name,


### PR DESCRIPTION
Our project is seeing multiple devices left in other locales which causes some of our tests to fail. This option allows us to specify the locale we want the devices to run with.