### PR TITLE
Return scheduled run as result

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -57,7 +57,7 @@ module Fastlane
         raise 'Binary upload failed. 🙈' unless upload.status == 'SUCCEEDED'
 
         # Schedule the run.
-        run = schedule_run params[:run_name], project, device_pool, upload, test_upload, type, params
+        scheduled_run = schedule_run params[:run_name], project, device_pool, upload, test_upload, type, params
 
         # Wait for run to finish.
         # rubocop:disable  Metrics/BlockNesting
@@ -75,6 +75,8 @@ module Fastlane
         else
           UI.message 'Successfully scheduled the tests on the AWS device farm. ✅'.green
         end
+        
+        run = scheduled_run
       end
       # rubocop:enable  Metrics/BlockNesting
       #


### PR DESCRIPTION
Previously plugin run result was just `True`, because run result was `UI.message` method call result.
This PR fixes that issue so that run result can then be used for further steps in lane.