### PR TITLE
Add support for XCTest

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -36,7 +36,9 @@ module Fastlane
           else
             if type == "ANDROID_APP"
               test_upload = create_project_upload project, test_path, 'INSTRUMENTATION_TEST_PACKAGE'
-            else
+            elsif params[:is_unit_test] == true
+              test_upload = create_project_upload project, test_path, 'XCTEST_TEST_PACKAGE'
+            else 
               test_upload = create_project_upload project, test_path, 'XCTEST_UI_TEST_PACKAGE'
             end
           end
@@ -354,9 +356,12 @@ module Fastlane
           if params[:test_type]
             test_hash[:type] = params[:test_type]
           else
-            test_hash[:type] = 'XCTEST_UI'
             if type == "ANDROID_APP"
               test_hash[:type] = 'INSTRUMENTATION'
+            elsif params[:is_unit_test] == true
+              test_hash[:type] = 'XCTEST'
+            else
+              test_hash[:type] = 'XCTEST_UI'
             end
           end
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -12,7 +12,7 @@ module Fastlane
 
         # Fetch the project
         project = fetch_project params[:name]
-        raise "Project '#{params[:name]}' not be found on AWS - please go to 'Device Farm' and create a project named: 'fastlane', or set the 'name' parameter with your custom message." if project.nil?
+        raise "Project '#{params[:name]}' not found on AWS - please go to 'Device Farm' and create a project named: 'fastlane', or set the 'name' parameter with your custom message." if project.nil?
 
         # Fetch the device pool.
         device_pool = fetch_device_pool project, params[:device_pool]

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_package.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_package.rb
@@ -53,6 +53,17 @@ module Fastlane
             is_string:   true,
             optional:    true,
             default_value: "Development"
+          ),
+          FastlaneCore::ConfigItem.new(
+            key:         :is_unit_test,
+            env_name:    'FL_AWS_DEVICE_FARM_IS_UNIT_TEST',
+            description: 'Specify is_unit_test to true if this is an iOS unit test',
+            is_string:   false,
+            optional:    true,
+            default_value: false,
+            verify_block: proc do |value|
+              UI.user_error!("Please pass a valid value for is_unit_test. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+            end
           )
         ]
       end


### PR DESCRIPTION
This is to support uploading test_package_type XCTEST_TEST_PACKAGE by specifying is_unit_test in action aws_device_farm_package

Really awesome work on fastlane! Please edit as needed, thank you!