### PR TITLE
Add flag to disable waiting periods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The plugin also exposes two ENV variables in case you want to make additional ca
 |  test_spec |    | Define the device farm custom TestSpec ARN to use (can be obtained using the AWS CLI `devicefarm list-uploads` command) | String |
 |  filter |    | Define a filter for your test run and only run the tests in the filter (note that using `test_spec` overrides the `filter` option) | String |
 |  print_web_url_of_run  | false | Do you want to print the web url of run in the messages? | Boolean |
+|  print_waiting_periods | true | Do you want to print `.` while waiting for a run? | Boolean
 
 Possible types see: http://docs.aws.amazon.com/sdkforruby/api/Aws/DeviceFarm/Client.html#create_upload-instance_method
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -38,7 +38,7 @@ module Fastlane
               test_upload = create_project_upload project, test_path, 'INSTRUMENTATION_TEST_PACKAGE'
             elsif params[:test_type] == 'XCTEST'
               test_upload = create_project_upload project, test_path, 'XCTEST_TEST_PACKAGE'
-            else 
+            else
               test_upload = create_project_upload project, test_path, 'XCTEST_UI_TEST_PACKAGE'
             end
           end
@@ -283,6 +283,14 @@ module Fastlane
             is_string:   false,
             optional:    true,
             default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :print_waiting_periods,
+            env_name: 'FL_AWS_DEVICE_FARM_PRINT_WAITING_PERIODS',
+            description: 'Prints a period while waiting for tests to complete.',
+            is_string: false,
+            optional: true,
+            default_value: true
           )
         ]
       end
@@ -396,7 +404,9 @@ module Fastlane
       def self.wait_for_run(project, run)
         while run.status != 'COMPLETED'
           sleep POLLING_INTERVAL
-          print '.'
+          if params[:print_waiting_periods]
+            print '.'
+          end
           run = fetch_run_status run
         end
         UI.message "The run ended with result #{run.result}."


### PR DESCRIPTION
Adds a flag to allow for disabling of the printing of periods while waiting for a run. This is useful for CircleCI if you want to cancel the job with a timeout. You would use this with CircleCI's `no_output_timeout`