### PR TITLE
fix: Do not let descriptions end with a '.', since it's used for user inputs as well for key :print_waiting_periods [WIP]

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -90,11 +90,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Upload the application to the AWS device farm.'
+        'Upload the application to the AWS device farm'
       end
 
       def self.details
-        'Upload the application to the AWS device farm.'
+        'Upload the application to the AWS device farm'
       end
 
       def self.available_options


### PR DESCRIPTION
This PR is to remove the period at the end of the description that causes this error when running this plugin using fastlane version 2.141.0