### PR TITLE
Fixes: Illegal period in action description and use of an out of scope variable

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -8,7 +8,7 @@ module Fastlane
         UI.message 'Preparing the upload to the device farm.'
 
         # Instantiate the client.
-        @client = ::Aws::DeviceFarm::Client.new
+        @client = ::Aws::DeviceFarm::Client.new()
 
         # Fetch the project
         project = fetch_project params[:name]
@@ -68,7 +68,7 @@ module Fastlane
         # rubocop:disable  Metrics/BlockNesting
         if params[:wait_for_completion]
           UI.message 'Waiting for the run to complete. ☕️'
-          run = wait_for_run project, run
+          run = wait_for_run project, run, params
           if params[:allow_failed_tests] == false
             if params[:allow_device_errors] == true
               raise "#{run.message} Failed 🙈" unless %w[PASSED WARNED ERRORED].include? run.result
@@ -401,7 +401,7 @@ module Fastlane
         }).run
       end
 
-      def self.wait_for_run(project, run)
+      def self.wait_for_run(project, run, params)
         while run.status != 'COMPLETED'
           sleep POLLING_INTERVAL
           if params[:print_waiting_periods]

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -8,7 +8,7 @@ module Fastlane
         UI.message 'Preparing the upload to the device farm.'
 
         # Instantiate the client.
-        @client = ::Aws::DeviceFarm::Client.new()
+        @client = ::Aws::DeviceFarm::Client.new
 
         # Fetch the project
         project = fetch_project params[:name]

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -90,11 +90,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Upload the application to the AWS device farm.'
+        'Upload the application to the AWS device farm'
       end
 
       def self.details
-        'Upload the application to the AWS device farm.'
+        'Upload the application to the AWS device farm'
       end
 
       def self.available_options


### PR DESCRIPTION
I found 2 small issues while attempting to use this plugin:

My environment:
Ruby 2.6.5
fastlane 2.141.0

I fixed the following issues:

1. Removes the illegal period used in the description of the `aws_device_farm_action`
2. Corrected the use of a params variable that was previously outside the scope of the `self.wait_for_run` method.

Based on these small changes I was able to successfully use this plugin by referencing my fork in the Pluginfile.