### PR TITLE
Support multiple devices for JUnit.xml 

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -495,8 +495,8 @@ module Fastlane
             }
 
             # need multi device support
-            file_path = "#{params[:junit_xml_output_path]}-#{j.name}-#{j.device.os}"
-            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: file_path) if params[:junit_xml]
+            file_prefix = "#{j.name}-#{j.device.os}"
+            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: file_path, file_prefix: file_prefix) if params[:junit_xml]
           end
         end
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -493,7 +493,10 @@ module Fastlane
               "time"     => j.device_minutes.metered,
               "test_suites" => test_suites
             }
-            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: params[:junit_xml_output_path]) if params[:junit_xml]
+
+            # need multi device support
+            file_path = "#{params[:junit_xml_output_path]}-#{j.name}-#{j.device.os}"
+            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: file_path) if params[:junit_xml]
           end
         end
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -496,7 +496,7 @@ module Fastlane
 
             # need multi device support
             file_prefix = "#{j.name}-#{j.device.os}"
-            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: file_path, file_prefix: file_prefix) if params[:junit_xml]
+            Helper::AwsDeviceFarmHelper.create_junit_xml(test_results: test_results, file_path: params[:junit_xml_output_path], file_prefix: file_prefix) if params[:junit_xml]
           end
         end
 

--- a/lib/fastlane/plugin/aws_device_farm/helper/aws_device_farm_helper.rb
+++ b/lib/fastlane/plugin/aws_device_farm/helper/aws_device_farm_helper.rb
@@ -6,7 +6,7 @@ module Fastlane
     class AwsDeviceFarmHelper
 
       # create Junit.xml
-      def self.create_junit_xml(test_results:, file_path:)
+      def self.create_junit_xml(test_results:, file_path:, file_prefix:)
         doc = REXML::Document.new
         doc << REXML::XMLDecl.new('1.0', 'UTF-8')
 
@@ -37,8 +37,11 @@ module Fastlane
         end
 
         # output
-        FileUtils.mkdir_p(File.dirname(file_path))
-        File.open(file_path, 'w') do |file|
+        file_name = "#{file_prefix}-#{File.basename(file_path)}"
+        file_dir_path = File.dirname(file_path)
+
+        FileUtils.mkdir_p(file_dir_path)
+        File.open("#{file_dir_path}/#{file_name}", 'w') do |file|
           doc.write(file, indent=2)
         end
       end


### PR DESCRIPTION
When Device-Pool have some devices, overrite JUnit.xml
so, add prefix words(device unique info) for file name
   - i.e.) now:  ./test_outputs/junit.xml  ->  ./test_outputs/#{prefix}-junit.xml
   - prefix rule:  #{device.name} - #{device.os}  /  Google Pixel XL-8.0.0-junit.xml
