### PR TITLE
Fix v0.3.18 - Add missing comma

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -234,7 +234,7 @@ module Fastlane
             env_name:    'FL_AWS_DEVICE_FARM_NETWORK_PROFILE_ARN',
             description: 'Network profile arn you want to use for running the applications',
             default_value: nil,
-            optional:    false
+            optional:    false,
             is_string:   true,
             optional:    false
           ),         


### PR DESCRIPTION
This was causing the plugin to fail on v0.3.18.