### PR TITLE
Fix warning key optional is duplicated and overwritten on line 239

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -235,8 +235,7 @@ module Fastlane
             description: 'Network profile arn you want to use for running the applications',
             default_value: nil,
             optional:    false,
-            is_string:   true,
-            optional:    false
+            is_string:   true
           ),         
           FastlaneCore::ConfigItem.new(
             key:           :wait_for_completion,


### PR DESCRIPTION
Removes duplicate `:optional` declaration