### PR TITLE
Add :additional_configuration param

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -350,7 +350,13 @@ module Fastlane
                                 'SCREENSHOT']
                 raise "Artifact type concludes invalid values are: '#{(value - valid_values)}'. 🙈".red unless (value - valid_values).empty?
               end
-          )
+          ),
+          FastlaneCore::ConfigItem.new(
+            key:         :additional_configuration,
+            description: 'Additional configuration settings',
+            type:        Hash,
+            optional:    true,
+          ),
         ]
       end
 
@@ -444,9 +450,14 @@ module Fastlane
         }
 
         # Get the network profile from params if value is provided
-      if params[:network_profile_arn]
-        configuration_hash[:network_profile_arn] = params[:network_profile_arn]
-      end
+        if params[:network_profile_arn]
+          configuration_hash[:network_profile_arn] = params[:network_profile_arn]
+        end
+
+        # Add additional configuration arguments if provided.
+        if params[:additional_configuration]
+          configuration_hash.update(params[:additional_configuration])
+        end
 
         @client.schedule_run({
           name:            name,


### PR DESCRIPTION
Add an `:additional_configuration` hash parameter that is merged into the `:configuration` hash that is passed to the AWS SDK client.  This is a general way of adding support for all `:configuration` options without needing to add a `ConfigItem` for each one.

FWIW I added this to support `auxiliary_apps` for Android Test Orchestrator.