### PR TITLE
- Add test parameters;

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The plugin also exposes two ENV variables in case you want to make additional ca
 |  artifact | `false` | Do you want to download Artifact? | Boolean |  |
 |  artifact_output_dir | `./test_outputs` | Artifact output directory | String |  |
 |  artifact_types | `[]` | Specify the artifact types one wants to download | Array |  |
+|  test_parameters |    |The test's parameters, such as test framework parameters and fixture settings. Parameters are represented by name-value pairs of strings. | Hash |  |
 
 
 Possible types see: http://docs.aws.amazon.com/sdkforruby/api/Aws/DeviceFarm/Client.html#create_upload-instance_method

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -356,6 +356,12 @@ module Fastlane
             type:        Hash,
             optional:    true,
           ),
+          FastlaneCore::ConfigItem.new(
+            key:         :test_parameters,
+            description: 'The test parameters',
+            type:        Hash,
+            optional:    true,
+          ),
         ]
       end
 
@@ -423,6 +429,11 @@ module Fastlane
       def self.schedule_run(name, project, device_pool, upload, test_upload, type, params)
         # Prepare the test hash depening if you passed the test apk.
         test_hash = { type: 'BUILTIN_FUZZ' }
+
+        if params[:test_parameters]
+          test_hash[:parameters] = params[:test_parameters]
+        end
+
         if test_upload
           if params[:test_type]
             test_hash[:type] = params[:test_type]


### PR DESCRIPTION
Hi @hjanuschka !

Sorry to bother you, but I wanted to add ability to provide test parameters as [described here](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DeviceFarm/Types/ScheduleRunTest.html#parameters-instance_method), mainly to have opportunity to set up `event_count` for Built in Fuzz test case, but it will give opportunity to provide enhanced set of settings for other test cases too.

Can you please check this?
Thank you in advance!