### PR TITLE
Fix `list_artifacts` type argument translation

### DIFF
--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -346,7 +346,8 @@ module Fastlane
               default_value: [],
               verify_block: proc do |value|
                 valid_values = ['LOG',
-                                'SCREENSHOT']
+                                'SCREENSHOT', 
+                                'CUSTOMER_ARTIFACT']
                 raise "Artifact type concludes invalid values are: '#{(value - valid_values)}'. 🙈".red unless (value - valid_values).empty?
               end
           ),
@@ -523,7 +524,7 @@ module Fastlane
           rows << [status, j.name, j.device.form_factor, j.device.platform, j.device.os]
 
           # artifact
-          artifact_support_types = %w(LOG SCREENSHOT)
+          artifact_support_types = %w(LOG SCREENSHOT CUSTOMER_ARTIFACT)
           params[:artifact_types].each do |type|
             next unless artifact_support_types.include?(type) && params[:artifact]
 
@@ -537,6 +538,8 @@ module Fastlane
               when "LOG"
                 file_name = "#{artifact.name}.#{artifact.extension}"
               when "SCREENSHOT"
+                file_name = "#{artifact.name}.#{artifact.extension}"
+              when "CUSTOMER_ARTIFACT"
                 file_name = "#{artifact.name}.#{artifact.extension}"
               end
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -347,7 +347,7 @@ module Fastlane
               verify_block: proc do |value|
                 valid_values = ['LOG',
                                 'SCREENSHOT', 
-                                'CUSTOMER_ARTIFACT']
+                                'FILE']
                 raise "Artifact type concludes invalid values are: '#{(value - valid_values)}'. 🙈".red unless (value - valid_values).empty?
               end
           ),
@@ -524,13 +524,13 @@ module Fastlane
           rows << [status, j.name, j.device.form_factor, j.device.platform, j.device.os]
 
           # artifact
-          artifact_support_types = %w(LOG SCREENSHOT CUSTOMER_ARTIFACT)
+          artifact_support_types = %w(LOG SCREENSHOT FILE)
           params[:artifact_types].each do |type|
             next unless artifact_support_types.include?(type) && params[:artifact]
 
             artifact = @client.list_artifacts({
                          arn: j.arn,
-                         type: ['LOG', 'SCREENSHOT'].include?(type) ? type : 'FILE'
+                         type: type
                        })
 
             artifact.artifacts.each do |artifact|
@@ -539,7 +539,7 @@ module Fastlane
                 file_name = "#{artifact.name}.#{artifact.extension}"
               when "SCREENSHOT"
                 file_name = "#{artifact.name}.#{artifact.extension}"
-              when "CUSTOMER_ARTIFACT"
+              when "FILE"
                 file_name = "#{artifact.name}.#{artifact.extension}"
               end
 

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -530,7 +530,7 @@ module Fastlane
 
             artifact = @client.list_artifacts({
                          arn: j.arn,
-                         type: type
+                         type: ['LOG', 'SCREENSHOT'].include?(type) ? type : 'FILE'
                        })
 
             artifact.artifacts.each do |artifact|

--- a/lib/fastlane/plugin/aws_device_farm/version.rb
+++ b/lib/fastlane/plugin/aws_device_farm/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AwsDeviceFarm
-    VERSION = "0.3.24"
+    VERSION = "0.3.26"
   end
 end


### PR DESCRIPTION
The `aws` client `list_artifacts` type argument has only 3 supported types. `LOG`, `SCREENSHOT` and `FILE`. I added a check to translate any `artifact_types` different from `LOG` or `SCREENSHOT` to use the`FILE` type.