### PR TITLE
Use aws-sdk-devicefarm service gem

### DIFF
--- a/fastlane-plugin-aws_device_farm.gemspec
+++ b/fastlane-plugin-aws_device_farm.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-devicefarm'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', '>= 1.105.0'

--- a/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
+++ b/lib/fastlane/plugin/aws_device_farm/actions/aws_device_farm_action.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-devicefarm'
 
 module Fastlane
   module Actions


### PR DESCRIPTION
Rather than pulling in the full aws-sdk gem that brings along a gem for every service, since we only need DeviceFarm in this case.